### PR TITLE
Fix unseen label issue in smaller data set during cross validation

### DIFF
--- a/gama/GamaClassifier.py
+++ b/gama/GamaClassifier.py
@@ -131,6 +131,13 @@ class GamaClassifier(Gama):
             # If target values are `str` we encode them or scikit-learn will complain.
             y = self._label_encoder.transform(y_)
         self._evaluation_library.determine_sample_indices(stratify=y)
+
+        # Add label information for classification to the scorer such that
+        # the cross validator does not encounter unseen labels in smaller
+        # data sets during pipeline evaluation.
+        for m in self._metrics:
+            m.scorer._kwargs.update({"labels": y})
+
         super().fit(x, y, *args, **kwargs)
 
     def _encode_labels(self, y):

--- a/gama/GamaClassifier.py
+++ b/gama/GamaClassifier.py
@@ -136,7 +136,8 @@ class GamaClassifier(Gama):
         # the cross validator does not encounter unseen labels in smaller
         # data sets during pipeline evaluation.
         for m in self._metrics:
-            m.scorer._kwargs.update({"labels": y})
+            if "labels" in inspect.signature(m.scorer._score_func).parameters:
+                m.scorer._kwargs.update({"labels": y})
 
         super().fit(x, y, *args, **kwargs)
 

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -33,7 +33,7 @@ import gama.genetic_programming.compilers.scikitlearn
 from gama.genetic_programming.components import Individual, Fitness, DATA_TERMINAL
 from gama.search_methods.base_search import BaseSearch
 from gama.utilities.evaluation_library import EvaluationLibrary, Evaluation
-from gama.utilities.metrics import MetricType, scoring_to_metric
+from gama.utilities.metrics import scoring_to_metric
 
 from gama.__version__ import __version__
 from gama.data_loading import X_y_from_file
@@ -512,13 +512,6 @@ class Gama(ABC):
             store_pipelines = (
                 self._evaluation_library._m is None or self._evaluation_library._m > 0
             )
-
-            # Add label information for classification to the scorer such that
-            # the cross validator does not encounter unseen labels in smaller
-            # data sets during pipeline evaluation.
-            for m in self._metrics:
-                if m.task_type == MetricType.CLASSIFICATION:
-                    m.scorer._kwargs.update({"labels": self._y})
 
             if store_pipelines and self._x.shape[0] * self._x.shape[1] > 6_000_000:
                 # if m > 0, we are storing models for each evaluation. For this size

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -518,7 +518,7 @@ class Gama(ABC):
             # data sets during pipeline evaluation.
             for m in self._metrics:
                 if m.task_type == MetricType.CLASSIFICATION:
-                    m.scorer._kwargs = {"labels": self._y}
+                    m.scorer._kwargs.update({"labels": self._y})
 
             if store_pipelines and self._x.shape[0] * self._x.shape[1] > 6_000_000:
                 # if m > 0, we are storing models for each evaluation. For this size

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -33,7 +33,7 @@ import gama.genetic_programming.compilers.scikitlearn
 from gama.genetic_programming.components import Individual, Fitness, DATA_TERMINAL
 from gama.search_methods.base_search import BaseSearch
 from gama.utilities.evaluation_library import EvaluationLibrary, Evaluation
-from gama.utilities.metrics import scoring_to_metric
+from gama.utilities.metrics import MetricType, scoring_to_metric
 
 from gama.__version__ import __version__
 from gama.data_loading import X_y_from_file
@@ -513,11 +513,12 @@ class Gama(ABC):
                 self._evaluation_library._m is None or self._evaluation_library._m > 0
             )
 
-            # Add label information to the scorer such that the cross validator
-            # does not encounter unseen labels in smaller data sets during
-            # pipeline evaluation.
+            # Add label information for classification to the scorer such that
+            # the cross validator does not encounter unseen labels in smaller
+            # data sets during pipeline evaluation.
             for m in self._metrics:
-                m.scorer._kwargs = {"labels": self._y}
+                if m.task_type == MetricType.CLASSIFICATION:
+                    m.scorer._kwargs = {"labels": self._y}
 
             if store_pipelines and self._x.shape[0] * self._x.shape[1] > 6_000_000:
                 # if m > 0, we are storing models for each evaluation. For this size

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -509,10 +509,16 @@ class Gama(ABC):
                 self._operator_set._compile,
                 preprocessing_steps=self._fixed_pipeline_extension,
             )
-
             store_pipelines = (
                 self._evaluation_library._m is None or self._evaluation_library._m > 0
             )
+
+            # Add label information to the scorer such that the cross validator
+            # does not encounter unseen labels in smaller data sets during
+            # pipeline evaluation.
+            for m in self._metrics:
+                m.scorer._kwargs = {"labels": self._y}
+
             if store_pipelines and self._x.shape[0] * self._x.shape[1] > 6_000_000:
                 # if m > 0, we are storing models for each evaluation. For this size
                 # KNN will create models of about 76Mb in size, which is too big, so

--- a/gama/genetic_programming/compilers/scikitlearn.py
+++ b/gama/genetic_programming/compilers/scikitlearn.py
@@ -110,7 +110,7 @@ def evaluate_pipeline(
                 y_train,
                 cv=splitter,
                 return_estimator=True,
-                scoring=[m.name for m in metrics],
+                scoring=dict([(m.name, m) for m in metrics]),
                 error_score="raise",
             )
             scores = tuple([np.mean(result[f"test_{m.name}"]) for m in metrics])

--- a/gama/utilities/preprocessing.py
+++ b/gama/utilities/preprocessing.py
@@ -57,7 +57,7 @@ def basic_encoding(x: pd.DataFrame, is_classification: bool):
 
     encoding_steps = [
         ("ord-enc", ce.OrdinalEncoder(cols=ord_features, drop_invariant=True)),
-        ("oh-enc", ce.OneHotEncoder(cols=leq_10_features, handle_missing="ignore")),
+        ("oh-enc", ce.OneHotEncoder(cols=leq_10_features, handle_missing="value")),
     ]
     encoding_pipeline = Pipeline(encoding_steps)
     x_enc = encoding_pipeline.fit_transform(x, y=None)  # Is this dangerous?


### PR DESCRIPTION
Fix for issue #150, where smaller data sets (especially for labels with few samples) could lead to errors in the cross validation during pipeline evaluation. The fix is to simply provide the set of labels to the `scorer` so that it knows all the possible labels beforehand. After shortly verifying the possible [classification scorers](https://scikit-learn.org/stable/modules/model_evaluation.html#scoring-parameter), we assume that all scorers accept a `labels` argument. 