### PR TITLE
Fix scikit-learn to <1.3, prepare post release

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+Version 23.0.0.post1
+--------------
+
+Fix scikit-learn to version <1.3, because GAMA uses scikit-learn internals that were changed from 1.4.
 
 Version 23.0.0
 --------------

--- a/gama/__version__.py
+++ b/gama/__version__.py
@@ -1,2 +1,2 @@
 # format: YY.minor.micro
-__version__ = "23.0.0"
+__version__ = "23.0.0.post1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.9"
 dependencies = [    
   "numpy>=1.20.0",
   "scipy>=1.0.0",
-  "scikit-learn>=1.1.0",
+  "scikit-learn>=1.1.0,<1.3",
   "pandas>=1.0",
   "stopit>=1.1.1",
   "liac-arff>=2.2.2",


### PR DESCRIPTION
GAMA builds on scikit-learn internals which changed from scikit-learn 1.3 onwards. This post release ensures a compatible version of scikit-learn is installed when installing GAMA.